### PR TITLE
package.json: Do not run postinstall in libs

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,6 @@
     "jshint-groups": "0.6.0"
   },
   "scripts": {
-    "postinstall": "bower-npm-install",
     "deps": "bower-npm-install --non-interactive",
     "lint": "jshint-groups && jscs . && csscomb -vl ."
   },


### PR DESCRIPTION
When you use a library on a project you actualy don't want it's deps to be installed. And sometimes it's even introduce errors.

// cc @tavriaforever
