### PR TITLE
Update bem-components to 2.3.0

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -23,7 +23,7 @@
     "Ivan Voischev <voischev.ivan@ya.ru>"
   ],
   "dependencies": {
-    "bem-components": "2.1.0"
+    "bem-components": "2.3.0"
   },
   "license": "MIT"
 }


### PR DESCRIPTION
Due to bower ECONFLICT error when installing latest version of bem-social & latest bem-components.